### PR TITLE
Nuevas funcionalidades para tú PasswordManager

### DIFF
--- a/README
+++ b/README
@@ -27,6 +27,8 @@ TODO:
  
 REQUIREMENTS:
  * Django 1.4
+ * South
+ * Dateutil
 
 ###########
 HOWTO
@@ -59,6 +61,9 @@ Superuser created successfully.
 Installing custom SQL ...
 Installing indexes ...
 Installed 0 object(s) from 0 fixture(s)
+
+vmalaga@dbalinux:~/PasswordManager$ ./manage.py migrate passManager
+...
 
 STATICS
 

--- a/passManager/admin.py
+++ b/passManager/admin.py
@@ -80,7 +80,8 @@ class ITServiceAdmin(admin.ModelAdmin):
     ordering = ['id']
     inlines = [ITConfigurationItemInLine]
     list_display = ["id","name","notes"]
-    list_editable = ["name","notes"]
+    list_editable = ["name"]
+    readonly_fields = []
 
 class passManagerItemInLine(admin.TabularInline):
     model = passDb
@@ -90,11 +91,12 @@ class passManagerItemInLine(admin.TabularInline):
     extra = 1
 
 class ITConfigurationItemAdmin(admin.ModelAdmin):
-    list_per_page = 40
+    list_per_page = 120
     ordering = ['id']
     inlines = [passManagerItemInLine]
     list_display = ["id","name","service","notes"]
-    list_editable = ["name","service","notes"]
+    list_editable = ["name","service"]
+    readonly_fields = []
 
 
 class passManagerAdmin(admin.ModelAdmin):

--- a/passManager/admin.py
+++ b/passManager/admin.py
@@ -114,7 +114,7 @@ class passManagerAdmin(admin.ModelAdmin):
     actions_on_top = True
     list_display_links = ['account']
     list_display = \
-      ('ci','account','version','login','getClickMe','server','uploader','creation_date','modification_date','send_email_html')
+      ('ci','account','version','login','getClickMe','modification_date','send_email_html')
     list_editable = []
     readonly_fields = [
         'creation_date',

--- a/passManager/admin.py
+++ b/passManager/admin.py
@@ -76,8 +76,8 @@ class ITConfigurationItemInLine(admin.TabularInline):
     extra = 1
 
 class ITServiceAdmin(admin.ModelAdmin):
-    list_per_page = 40
-    ordering = ['id']
+    list_per_page = 120
+    ordering = ['name']
     inlines = [ITConfigurationItemInLine]
     list_display = ["id","name","notes"]
     list_editable = ["name"]
@@ -92,9 +92,9 @@ class passManagerItemInLine(admin.TabularInline):
 
 class ITConfigurationItemAdmin(admin.ModelAdmin):
     list_per_page = 120
-    ordering = ['id']
+    ordering = ['service','name']
     inlines = [passManagerItemInLine]
-    list_display = ["id","name","service","notes"]
+    list_display = ["id","service","name","notes"]
     list_editable = ["name","service"]
     readonly_fields = []
 
@@ -209,7 +209,7 @@ class PasswordTypeAdmin(admin.ModelAdmin):
     list_per_page = 40
     ordering = ['id']
     list_display = ["id","name","notes"]
-    list_editable = ["name","notes"]
+    list_editable = ["name"]
 
 
 admin.site.register(passDb, passManagerAdmin)

--- a/passManager/admin.py
+++ b/passManager/admin.py
@@ -55,18 +55,51 @@ class passManagerAdmin(admin.ModelAdmin):
         css = {
             "all": ("jquery-ui-1.8.18.custom.css",)
         }
-        
-    list_per_page = 20
-    actions = ['export_as_json']    
+
+    ordering = ['modification_date']
+
+    list_per_page = 40
+    actions = ['export_as_json']
     actions_on_bottom = True
-    actions_on_top = False
+    actions_on_top = True
     list_display_links = ['name']
-    list_display = ('name','login','getClickMe','server','uploader','date','notes','send_email_html')
-    list_editable = ('login','server')
-    list_filter = (loginsFilter,'uploader','date')
+    list_display = \
+      ('name','login','getClickMe','server','uploader','creation_date','modification_date','notes','send_email_html')
+    list_editable = []
+    readonly_fields = [
+        'creation_date',
+        'modification_date',
+        "uploader",
+        "deprecated"
+    ]
+
+    list_filter = (loginsFilter,'uploader','creation_date',
+            "modification_date","deprecated")
     fieldsets = [
-                 (None,         {'fields': ['name',('login','password'),'server','notes']}),
-                 ]
+            (None,{
+              'fields': [
+                ('name','server'),
+                ('login','password'),
+            ]}),
+            ('Dates', {
+              'classes': ('collapse',),
+              'fields': (
+                (
+                "creation_date",
+                "modification_date"),
+                ("valid_since_date",
+                "valid_until_date"),
+              )
+            }),
+            ('Other info', {
+              'classes': ('collapse',),
+              'fields': (
+                ('uploader',"deprecated"),
+                ("notes"),
+              )
+            }),
+    ]
+
     search_fields = ['name','login','server','notes']
         
     def save_model(self, request, obj, form, change):

--- a/passManager/admin.py
+++ b/passManager/admin.py
@@ -59,7 +59,7 @@ class passManagerAdmin(admin.ModelAdmin):
     ordering = ['modification_date']
 
     list_per_page = 40
-    actions = ['export_as_json']
+    actions = ['export_as_json',"export_as_csv"]
     actions_on_bottom = True
     actions_on_top = True
     list_display_links = ['name']
@@ -124,6 +124,26 @@ class passManagerAdmin(admin.ModelAdmin):
         response = HttpResponse(mimetype="text/javascript")
         serializers.serialize("json", queryset, stream=response)
         return response
+
+    def export_as_csv(self, request, queryset):
+        from django.http import HttpResponse
+        from utils import helpers
+        import csv
+
+        # Create the HttpResponse object with the appropriate CSV header.
+        response = HttpResponse(content_type='text/csv')
+        response['Content-Disposition'] = 'attachment; filename="credentials.csv"'
+
+        writer = csv.writer(response)
+        headers = helpers.get_model_field_names(passDb)
+        headers.append("unencrypted_password")
+        writer.writerow(headers)
+        for o in queryset:
+            values = helpers.get_model_fields_values(o)
+            values.append(o._get_password())
+            writer.writerow(values)
+        return response
+
 
         
 admin.site.register(passDb, passManagerAdmin)

--- a/passManager/admin.py
+++ b/passManager/admin.py
@@ -79,9 +79,17 @@ class ITServiceAdmin(admin.ModelAdmin):
     list_per_page = 120
     ordering = ['name']
     inlines = [ITConfigurationItemInLine]
-    list_display = ["id","name","notes"]
+    list_display_links = ['edit_html']
+    list_display = ["name","notes","edit_html"]
     list_editable = ["name"]
     readonly_fields = []
+
+    def edit_html(self, queryset):
+        return '''<a href="%s/">Edit</a>''' % queryset.id
+    edit_html.short_description = ''
+    edit_html.allow_tags = True
+
+
 
 class passManagerItemInLine(admin.TabularInline):
     model = passDb
@@ -94,9 +102,15 @@ class ITConfigurationItemAdmin(admin.ModelAdmin):
     list_per_page = 120
     ordering = ['service','name']
     inlines = [passManagerItemInLine]
-    list_display = ["id","service","name","notes"]
+    list_display_links = ['edit_html']
+    list_display = ["service","name","notes","edit_html"]
     list_editable = ["name","service"]
     readonly_fields = []
+
+    def edit_html(self, queryset):
+        return '''<a href="%s/">Edit</a>''' % queryset.id
+    edit_html.short_description = ''
+    edit_html.allow_tags = True
 
 
 class passManagerAdmin(admin.ModelAdmin):

--- a/passManager/admin.py
+++ b/passManager/admin.py
@@ -120,7 +120,7 @@ class passManagerAdmin(admin.ModelAdmin):
             "all": ("jquery-ui-1.8.18.custom.css",)
         }
 
-    ordering = ['-modification_date']
+    ordering = ['name']
 
     form = passManagerAdminForm
 
@@ -134,8 +134,10 @@ class passManagerAdmin(admin.ModelAdmin):
     actions_on_top = True
     list_display_links = ['name']
     list_display = \
-      ('name','version','active','login','server','getClickMe','modification_date','send_email_html')
-    list_editable = []
+      ('name','version','login','server','getClickMe','notes','send_email_html')
+    list_editable = \
+      ('version','login','server')
+
     readonly_fields = [
         'creation_date',
         'modification_date',
@@ -144,8 +146,11 @@ class passManagerAdmin(admin.ModelAdmin):
         "name"
     ]
 
-    list_filter = (loginsFilter,'uploader','creation_date',
-            "modification_date","deprecated","service_name")
+    list_filter = ('deprecated', 'service_name',loginsFilter,'creation_date',
+           "modification_date",'uploader')
+
+    date_hierarchy = 'modification_date'
+
     fieldsets = [
             (None,{
               'fields': [
@@ -163,7 +168,7 @@ class passManagerAdmin(admin.ModelAdmin):
               )
             }),
             ('Other info', {
-              'classes': ('collapse',),
+              'classes': (),
               'fields': (
                 ("notes"),
               )
@@ -177,7 +182,12 @@ class passManagerAdmin(admin.ModelAdmin):
         obj.uploader = request.user
         obj.nivel = 1
         obj.save()
-    
+
+    def edit_html(self, queryset):
+        return '''<a href="%s/">Edit</a>''' % queryset.id
+    edit_html.short_description = ''
+    edit_html.allow_tags = True
+
     def send_email_html(self, queryset):
         buttons = """                                                                                                                                                            
             <div style="width:20px">                                                                                                                                             

--- a/passManager/admin.py
+++ b/passManager/admin.py
@@ -60,7 +60,9 @@ class passManagerAdmin(admin.ModelAdmin):
     actions = ['export_as_json']    
     actions_on_bottom = True
     actions_on_top = False
+    list_display_links = ['name']
     list_display = ('name','login','getClickMe','server','uploader','date','notes','send_email_html')
+    list_editable = ('login','server')
     list_filter = (loginsFilter,'uploader','date')
     fieldsets = [
                  (None,         {'fields': ['name',('login','password'),'server','notes']}),

--- a/passManager/migrations/0001_initial.py
+++ b/passManager/migrations/0001_initial.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'passDb'
+        db.create_table(u'passManager_passdb', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=100)),
+            ('login', self.gf('django.db.models.fields.CharField')(max_length=50)),
+            ('password', self.gf('django.db.models.fields.CharField')(max_length=100)),
+            ('server', self.gf('django.db.models.fields.CharField')(max_length=60)),
+            ('date', self.gf('django.db.models.fields.DateField')(auto_now=True, blank=True)),
+            ('uploader', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['auth.User'])),
+            ('notes', self.gf('django.db.models.fields.TextField')()),
+        ))
+        db.send_create_signal(u'passManager', ['passDb'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'passDb'
+        db.delete_table(u'passManager_passdb')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'passManager.passdb': {
+            'Meta': {'object_name': 'passDb'},
+            'date': ('django.db.models.fields.DateField', [], {'auto_now': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'login': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'server': ('django.db.models.fields.CharField', [], {'max_length': '60'}),
+            'uploader': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"})
+        }
+    }
+
+    complete_apps = ['passManager']

--- a/passManager/migrations/0002_auto__del_field_passdb_date__add_field_passdb_modification_date__add_f.py
+++ b/passManager/migrations/0002_auto__del_field_passdb_date__add_field_passdb_modification_date__add_f.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'passDb.date'
+        db.delete_column(u'passManager_passdb', 'date')
+
+        # Adding field 'passDb.modification_date'
+        db.add_column(u'passManager_passdb', 'modification_date',
+                      self.gf('django.db.models.fields.DateTimeField')(auto_now=True, null=True, blank=True),
+                      keep_default=False)
+
+        # Adding field 'passDb.creation_date'
+        db.add_column(u'passManager_passdb', 'creation_date',
+                      self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime(2013, 11, 23, 0, 0)),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Adding field 'passDb.date'
+        db.add_column(u'passManager_passdb', 'date',
+                      self.gf('django.db.models.fields.DateField')(auto_now=True, default=datetime.datetime(2013, 11, 23, 0, 0), blank=True),
+                      keep_default=False)
+
+        # Deleting field 'passDb.modification_date'
+        db.delete_column(u'passManager_passdb', 'modification_date')
+
+        # Deleting field 'passDb.creation_date'
+        db.delete_column(u'passManager_passdb', 'creation_date')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'passManager.passdb': {
+            'Meta': {'object_name': 'passDb'},
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'login': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'modification_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'server': ('django.db.models.fields.CharField', [], {'max_length': '60'}),
+            'uploader': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"})
+        }
+    }
+
+    complete_apps = ['passManager']

--- a/passManager/migrations/0003_auto__add_field_passdb_deprecated__add_field_passdb_valid_since_date__.py
+++ b/passManager/migrations/0003_auto__add_field_passdb_deprecated__add_field_passdb_valid_since_date__.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'passDb.deprecated'
+        db.add_column(u'passManager_passdb', 'deprecated',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+        # Adding field 'passDb.valid_since_date'
+        db.add_column(u'passManager_passdb', 'valid_since_date',
+                      self.gf('django.db.models.fields.DateTimeField')(default=None, null=True, blank=True),
+                      keep_default=False)
+
+        # Adding field 'passDb.valid_until_date'
+        db.add_column(u'passManager_passdb', 'valid_until_date',
+                      self.gf('django.db.models.fields.DateTimeField')(default=None, null=True, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'passDb.deprecated'
+        db.delete_column(u'passManager_passdb', 'deprecated')
+
+        # Deleting field 'passDb.valid_since_date'
+        db.delete_column(u'passManager_passdb', 'valid_since_date')
+
+        # Deleting field 'passDb.valid_until_date'
+        db.delete_column(u'passManager_passdb', 'valid_until_date')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'passManager.passdb': {
+            'Meta': {'object_name': 'passDb'},
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'deprecated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'login': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'modification_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'server': ('django.db.models.fields.CharField', [], {'max_length': '60'}),
+            'uploader': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'valid_since_date': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'valid_until_date': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['passManager']

--- a/passManager/migrations/0004_auto__chg_field_passdb_notes.py
+++ b/passManager/migrations/0004_auto__chg_field_passdb_notes.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'passDb.notes'
+        db.alter_column(u'passManager_passdb', 'notes', self.gf('django.db.models.fields.TextField')(null=True))
+
+    def backwards(self, orm):
+
+        # Changing field 'passDb.notes'
+        db.alter_column(u'passManager_passdb', 'notes', self.gf('django.db.models.fields.TextField')(default=''))
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'passManager.passdb': {
+            'Meta': {'object_name': 'passDb'},
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'deprecated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'login': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'modification_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'server': ('django.db.models.fields.CharField', [], {'max_length': '60'}),
+            'uploader': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'valid_since_date': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'valid_until_date': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['passManager']

--- a/passManager/migrations/0005_auto__add_itservice__add_passwordtype__add_itconfigurationitem__add_fi.py
+++ b/passManager/migrations/0005_auto__add_itservice__add_passwordtype__add_itconfigurationitem__add_fi.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'ITService'
+        db.create_table(u'passManager_itservice', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=500)),
+            ('notes', self.gf('django.db.models.fields.TextField')(default='', null=True, blank=True)),
+        ))
+        db.send_create_signal(u'passManager', ['ITService'])
+
+        # Adding model 'PasswordType'
+        db.create_table(u'passManager_passwordtype', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=100)),
+            ('notes', self.gf('django.db.models.fields.TextField')(default='', null=True, blank=True)),
+        ))
+        db.send_create_signal(u'passManager', ['PasswordType'])
+
+        # Adding model 'ITConfigurationItem'
+        db.create_table(u'passManager_itconfigurationitem', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=100)),
+            ('notes', self.gf('django.db.models.fields.TextField')(default='', null=True, blank=True)),
+            ('service', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['passManager.ITService'])),
+        ))
+        db.send_create_signal(u'passManager', ['ITConfigurationItem'])
+
+        # Adding field 'passDb.account'
+        db.add_column(u'passManager_passdb', 'account',
+                      self.gf('django.db.models.fields.CharField')(default='noname', max_length=100),
+                      keep_default=False)
+
+        # Adding field 'passDb.version'
+        db.add_column(u'passManager_passdb', 'version',
+                      self.gf('django.db.models.fields.IntegerField')(default=1),
+                      keep_default=False)
+
+
+        # Changing field 'passDb.name'
+        db.alter_column(u'passManager_passdb', 'name', self.gf('django.db.models.fields.CharField')(max_length=500))
+
+    def backwards(self, orm):
+        # Deleting model 'ITService'
+        db.delete_table(u'passManager_itservice')
+
+        # Deleting model 'PasswordType'
+        db.delete_table(u'passManager_passwordtype')
+
+        # Deleting model 'ITConfigurationItem'
+        db.delete_table(u'passManager_itconfigurationitem')
+
+        # Deleting field 'passDb.account'
+        db.delete_column(u'passManager_passdb', 'account')
+
+        # Deleting field 'passDb.version'
+        db.delete_column(u'passManager_passdb', 'version')
+
+
+        # Changing field 'passDb.name'
+        db.alter_column(u'passManager_passdb', 'name', self.gf('django.db.models.fields.CharField')(max_length=100))
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'passManager.itconfigurationitem': {
+            'Meta': {'object_name': 'ITConfigurationItem'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'}),
+            'service': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['passManager.ITService']"})
+        },
+        u'passManager.itservice': {
+            'Meta': {'object_name': 'ITService'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'})
+        },
+        u'passManager.passdb': {
+            'Meta': {'object_name': 'passDb'},
+            'account': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'deprecated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'login': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'modification_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'server': ('django.db.models.fields.CharField', [], {'max_length': '60'}),
+            'uploader': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'valid_since_date': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'valid_until_date': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'version': ('django.db.models.fields.IntegerField', [], {'default': '1'})
+        },
+        u'passManager.passwordtype': {
+            'Meta': {'object_name': 'PasswordType'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['passManager']

--- a/passManager/migrations/0006_auto__add_field_passdb_password_type__add_field_passdb_ci.py
+++ b/passManager/migrations/0006_auto__add_field_passdb_password_type__add_field_passdb_ci.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+import passManager
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'passDb.password_type'
+        db.add_column(u'passManager_passdb', 'password_type',
+                      self.gf('django.db.models.fields.related.ForeignKey')(default=passManager.models.PasswordType.objects.all()[0].id, to=orm['passManager.PasswordType']),
+                      keep_default=False)
+
+        # Adding field 'passDb.ci'
+        db.add_column(u'passManager_passdb', 'ci',
+                      self.gf('django.db.models.fields.related.ForeignKey')(default=passManager.models.ITConfigurationItem.objects.all()[0].id, to=orm['passManager.ITConfigurationItem']),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'passDb.password_type'
+        db.delete_column(u'passManager_passdb', 'password_type_id')
+
+        # Deleting field 'passDb.ci'
+        db.delete_column(u'passManager_passdb', 'ci_id')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'passManager.itconfigurationitem': {
+            'Meta': {'object_name': 'ITConfigurationItem'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'}),
+            'service': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['passManager.ITService']"})
+        },
+        u'passManager.itservice': {
+            'Meta': {'object_name': 'ITService'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'})
+        },
+        u'passManager.passdb': {
+            'Meta': {'object_name': 'passDb'},
+            'account': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'ci': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['passManager.ITConfigurationItem']"}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'deprecated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'login': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'modification_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'password_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['passManager.PasswordType']"}),
+            'server': ('django.db.models.fields.CharField', [], {'max_length': '60'}),
+            'uploader': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'valid_since_date': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'valid_until_date': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'version': ('django.db.models.fields.IntegerField', [], {'default': '1'})
+        },
+        u'passManager.passwordtype': {
+            'Meta': {'object_name': 'PasswordType'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['passManager']

--- a/passManager/migrations/0006_auto__add_field_passdb_password_type__add_field_passdb_ci.py
+++ b/passManager/migrations/0006_auto__add_field_passdb_password_type__add_field_passdb_ci.py
@@ -8,14 +8,31 @@ import passManager
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
+        try:
+            d_ = passManager.models.PasswordType.objects.get(name="Default")
+        except Exception:
+            d_ = passManager.models.PasswordType(name="Default")
+            d_.save()
         # Adding field 'passDb.password_type'
         db.add_column(u'passManager_passdb', 'password_type',
-                      self.gf('django.db.models.fields.related.ForeignKey')(default=passManager.models.PasswordType.objects.all()[0].id, to=orm['passManager.PasswordType']),
+                      self.gf('django.db.models.fields.related.ForeignKey')(default=d_.id, to=orm['passManager.PasswordType']),
                       keep_default=False)
 
+        try:
+            d_ = passManager.models.ITService.objects.get(name="Default")
+        except Exception:
+            d_ = passManager.models.ITService(name="Default")
+            d_.save()
+        try:
+            d_ = \
+passManager.models.ITConfigurationItem.objects.get(name="Default",service__name="Default")
+        except Exception:
+            d_ = \
+passManager.models.ITConfigurationItem(name="Default",service=d_)
+            d_.save()
         # Adding field 'passDb.ci'
         db.add_column(u'passManager_passdb', 'ci',
-                      self.gf('django.db.models.fields.related.ForeignKey')(default=passManager.models.ITConfigurationItem.objects.all()[0].id, to=orm['passManager.ITConfigurationItem']),
+                      self.gf('django.db.models.fields.related.ForeignKey')(default=d_.id, to=orm['passManager.ITConfigurationItem']),
                       keep_default=False)
 
 

--- a/passManager/migrations/0007_auto__add_field_passdb_service_name.py
+++ b/passManager/migrations/0007_auto__add_field_passdb_service_name.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'passDb.service_name'
+        db.add_column(u'passManager_passdb', 'service_name',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=500),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'passDb.service_name'
+        db.delete_column(u'passManager_passdb', 'service_name')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'passManager.itconfigurationitem': {
+            'Meta': {'object_name': 'ITConfigurationItem'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'}),
+            'service': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['passManager.ITService']"})
+        },
+        u'passManager.itservice': {
+            'Meta': {'object_name': 'ITService'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'})
+        },
+        u'passManager.passdb': {
+            'Meta': {'object_name': 'passDb'},
+            'account': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'ci': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['passManager.ITConfigurationItem']"}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'deprecated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'login': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'modification_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'password_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['passManager.PasswordType']"}),
+            'server': ('django.db.models.fields.CharField', [], {'max_length': '60'}),
+            'service_name': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'uploader': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'valid_since_date': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'valid_until_date': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'version': ('django.db.models.fields.IntegerField', [], {'default': '1'})
+        },
+        u'passManager.passwordtype': {
+            'Meta': {'object_name': 'PasswordType'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['passManager']

--- a/passManager/migrations/0008_auto__add_unique_passwordtype_name__add_unique_itservice_name.py
+++ b/passManager/migrations/0008_auto__add_unique_passwordtype_name__add_unique_itservice_name.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding unique constraint on 'PasswordType', fields ['name']
+        db.create_unique(u'passManager_passwordtype', ['name'])
+
+        # Adding unique constraint on 'ITService', fields ['name']
+        db.create_unique(u'passManager_itservice', ['name'])
+
+
+    def backwards(self, orm):
+        # Removing unique constraint on 'ITService', fields ['name']
+        db.delete_unique(u'passManager_itservice', ['name'])
+
+        # Removing unique constraint on 'PasswordType', fields ['name']
+        db.delete_unique(u'passManager_passwordtype', ['name'])
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'passManager.itconfigurationitem': {
+            'Meta': {'object_name': 'ITConfigurationItem'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'}),
+            'service': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['passManager.ITService']"})
+        },
+        u'passManager.itservice': {
+            'Meta': {'object_name': 'ITService'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '500'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'})
+        },
+        u'passManager.passdb': {
+            'Meta': {'object_name': 'passDb'},
+            'account': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'ci': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['passManager.ITConfigurationItem']"}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'deprecated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'login': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'modification_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'password_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['passManager.PasswordType']"}),
+            'server': ('django.db.models.fields.CharField', [], {'max_length': '60'}),
+            'service_name': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'uploader': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'valid_since_date': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'valid_until_date': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'version': ('django.db.models.fields.IntegerField', [], {'default': '1'})
+        },
+        u'passManager.passwordtype': {
+            'Meta': {'object_name': 'PasswordType'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['passManager']

--- a/passManager/migrations/0009_auto__chg_field_passdb_server.py
+++ b/passManager/migrations/0009_auto__chg_field_passdb_server.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'passDb.server'
+        db.alter_column('passManager_passdb', 'server', self.gf('django.db.models.fields.CharField')(max_length=60, null=True))
+
+    def backwards(self, orm):
+
+        # Changing field 'passDb.server'
+        db.alter_column('passManager_passdb', 'server', self.gf('django.db.models.fields.CharField')(default='', max_length=60))
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'passManager.itconfigurationitem': {
+            'Meta': {'object_name': 'ITConfigurationItem'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'}),
+            'service': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['passManager.ITService']"})
+        },
+        'passManager.itservice': {
+            'Meta': {'object_name': 'ITService'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '500'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'})
+        },
+        'passManager.passdb': {
+            'Meta': {'object_name': 'passDb'},
+            'account': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'ci': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['passManager.ITConfigurationItem']"}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'deprecated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'login': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'modification_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'password_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['passManager.PasswordType']"}),
+            'server': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '60', 'null': 'True', 'blank': 'True'}),
+            'service_name': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'uploader': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'valid_since_date': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'valid_until_date': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'version': ('django.db.models.fields.IntegerField', [], {'default': '1'})
+        },
+        'passManager.passwordtype': {
+            'Meta': {'object_name': 'PasswordType'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['passManager']

--- a/passManager/migrations/0010_auto__add_field_passdb_active.py
+++ b/passManager/migrations/0010_auto__add_field_passdb_active.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'passDb.active'
+        db.add_column('passManager_passdb', 'active',
+                      self.gf('django.db.models.fields.BooleanField')(default=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'passDb.active'
+        db.delete_column('passManager_passdb', 'active')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'passManager.itconfigurationitem': {
+            'Meta': {'object_name': 'ITConfigurationItem'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'}),
+            'service': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['passManager.ITService']"})
+        },
+        'passManager.itservice': {
+            'Meta': {'object_name': 'ITService'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '500'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'})
+        },
+        'passManager.passdb': {
+            'Meta': {'object_name': 'passDb'},
+            'account': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'ci': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['passManager.ITConfigurationItem']"}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'deprecated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'login': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'modification_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'password_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['passManager.PasswordType']"}),
+            'server': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '60', 'null': 'True', 'blank': 'True'}),
+            'service_name': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'uploader': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'valid_since_date': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'valid_until_date': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'version': ('django.db.models.fields.IntegerField', [], {'default': '1'})
+        },
+        'passManager.passwordtype': {
+            'Meta': {'object_name': 'PasswordType'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['passManager']

--- a/passManager/migrations/0011_auto__add_field_passdb_active.py
+++ b/passManager/migrations/0011_auto__add_field_passdb_active.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+import passManager
+from django.db.models import F
+from django.db import transaction
+
+class Migration(SchemaMigration):
+
+    @transaction.commit_on_success
+    def forwards(self, orm):
+        for o in passManager.models.passDb.objects.all():
+            if o.deprecated == True:
+                o.active = False
+            else:
+                o.active = True
+            o.save()
+
+    def backwards(self, orm):
+        pass
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'passManager.itconfigurationitem': {
+            'Meta': {'object_name': 'ITConfigurationItem'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'}),
+            'service': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['passManager.ITService']"})
+        },
+        'passManager.itservice': {
+            'Meta': {'object_name': 'ITService'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '500'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'})
+        },
+        'passManager.passdb': {
+            'Meta': {'object_name': 'passDb'},
+            'account': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'ci': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['passManager.ITConfigurationItem']"}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'deprecated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'login': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'modification_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'password_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['passManager.PasswordType']"}),
+            'server': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '60', 'null': 'True', 'blank': 'True'}),
+            'service_name': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'uploader': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'valid_since_date': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'valid_until_date': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'version': ('django.db.models.fields.IntegerField', [], {'default': '1'})
+        },
+        'passManager.passwordtype': {
+            'Meta': {'object_name': 'PasswordType'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['passManager']

--- a/passManager/migrations/0012_auto__del_field_passdb_valid_since_date.py
+++ b/passManager/migrations/0012_auto__del_field_passdb_valid_since_date.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'passDb.valid_since_date'
+        db.delete_column('passManager_passdb', 'valid_since_date')
+
+
+    def backwards(self, orm):
+        # Adding field 'passDb.valid_since_date'
+        db.add_column('passManager_passdb', 'valid_since_date',
+                      self.gf('django.db.models.fields.DateTimeField')(default=None, null=True, blank=True),
+                      keep_default=False)
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'passManager.itconfigurationitem': {
+            'Meta': {'object_name': 'ITConfigurationItem'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'}),
+            'service': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['passManager.ITService']"})
+        },
+        'passManager.itservice': {
+            'Meta': {'object_name': 'ITService'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '500'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'})
+        },
+        'passManager.passdb': {
+            'Meta': {'object_name': 'passDb'},
+            'account': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'ci': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['passManager.ITConfigurationItem']"}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'deprecated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'login': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'modification_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'password_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['passManager.PasswordType']"}),
+            'server': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '60', 'null': 'True', 'blank': 'True'}),
+            'service_name': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'uploader': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'valid_until_date': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'version': ('django.db.models.fields.IntegerField', [], {'default': '1'})
+        },
+        'passManager.passwordtype': {
+            'Meta': {'object_name': 'PasswordType'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['passManager']

--- a/passManager/models.py
+++ b/passManager/models.py
@@ -41,7 +41,6 @@ class passDb(models.Model):
     
 
     def save(self, *args, **kwargs):
-
         d = datetime.datetime.fromtimestamp(time.time(), pytz.UTC)
         if not self.creation_date:
             self.creation_date = d

--- a/passManager/models.py
+++ b/passManager/models.py
@@ -1,19 +1,27 @@
 from django.contrib.auth.models import User
 from django.db import models
 from passManager.functions import passEncr
+import time
+import pytz
+import datetime
 
 class passDb(models.Model):
     class Meta:
         verbose_name = 'Password'
         
+    deprecated = models.BooleanField(default=False)
     name = models.CharField(max_length=100)
     login = models.CharField(max_length=50)
     password = models.CharField(max_length=100)
     server = models.CharField(max_length=60)
-    date = models.DateField(auto_now=True)
     uploader = models.ForeignKey(User)
-    notes = models.TextField()
- 
+    notes = models.TextField(null=True, blank=True, default = "")
+    creation_date = models.DateTimeField(editable=False)
+    modification_date = models.DateTimeField(auto_now=True, null=True,
+            blank=True)
+    valid_since_date = models.DateTimeField(null=True, blank=True, default = None)
+    valid_until_date = models.DateTimeField(null=True, blank=True, default = None)
+
     def __unicode__(self):
         return self.name
     
@@ -32,5 +40,13 @@ class passDb(models.Model):
         return password
     
 
+    def save(self, *args, **kwargs):
+
+        d = datetime.datetime.fromtimestamp(time.time(), pytz.UTC)
+        if not self.creation_date:
+            self.creation_date = d
+        if self.valid_until_date and self.valid_until_date < d:
+            self.deprecated = True
+        super(passDb, self).save(*args, **kwargs)
 
     

--- a/passManager/models.py
+++ b/passManager/models.py
@@ -4,16 +4,61 @@ from passManager.functions import passEncr
 import time
 import pytz
 import datetime
+from django.utils.translation import ugettext_lazy as _
+
+class ITService(models.Model):
+    class Meta:
+        verbose_name = 'IT Service'
+
+    def __unicode__(self):
+        return self.name
+
+    name = models.CharField(max_length=500) # Unique
+    notes = models.TextField(null=True, blank=True, default = "")
+
+class ITConfigurationItem(models.Model):
+    class Meta:
+        verbose_name = 'IT Configuration Item'
+
+    def __unicode__(self):
+        try:
+            service_str = self.service.__unicode__()
+        except Exception:
+            service_str = "no Service"
+
+        return self.service.__unicode__() + "::" + self.name
+
+    name = models.CharField(max_length=100)
+    notes = models.TextField(null=True, blank=True, default = "")
+    service = models.ForeignKey(ITService)
+
+class PasswordType(models.Model):
+    class Meta:
+        verbose_name = 'Type of credential'
+
+    def __unicode__(self):
+        try:
+            return self.name
+        except Exception:
+            return super(PasswordType, self).__unicode__(*args, **kwargs)
+
+    name = models.CharField(max_length=100) #Unique
+    notes = models.TextField(null=True, blank=True, default = "")
 
 class passDb(models.Model):
     class Meta:
         verbose_name = 'Password'
-        
+
     deprecated = models.BooleanField(default=False)
-    name = models.CharField(max_length=100)
+    account = models.CharField(max_length=100)
+    name = models.CharField(max_length=500)
+    version = models.IntegerField(default=1)
+    password_type = models.ForeignKey(PasswordType)
+    ci = models.ForeignKey(ITConfigurationItem)
     login = models.CharField(max_length=50)
     password = models.CharField(max_length=100)
     server = models.CharField(max_length=60)
+    service_name = models.CharField(max_length=500)
     uploader = models.ForeignKey(User)
     notes = models.TextField(null=True, blank=True, default = "")
     creation_date = models.DateTimeField(editable=False)
@@ -23,10 +68,17 @@ class passDb(models.Model):
     valid_until_date = models.DateTimeField(null=True, blank=True, default = None)
 
     def __unicode__(self):
-        return self.name
-    
+        try:
+            ci_str = self.ci.__unicode__()
+        except Exception:
+            ci_str = "no CI"
+        return ci_str + \
+                "::" + self.account + "::" + str(self.version)
+
+
     def getClickMe(self):
         password = passEncr('decrypt', self.password)
+        # TODO: BadSignature
         idrow = self.id
         return '<font color="red"><span id=\"%s\" onClick=\"cambiar(\'%s\',\'%s\');\">ClickME</span></font>' % (idrow, idrow, password)
     getClickMe.allow_tags = True
@@ -38,9 +90,29 @@ class passDb(models.Model):
         else:
             password = ""
         return password
-    
 
     def save(self, *args, **kwargs):
+
+        self.name = self.__unicode__()
+
+        self.service_name = self.ci.service.__unicode__()
+
+        v = self.version
+        while True:
+            passwd_list = passDb.objects.filter(ci=self.ci, account=self.account,
+                version=v)
+            if not self.id:
+                if len(passwd_list) > 0:
+                    v = v + 1
+                else:
+                     break
+            else:
+                if len(passwd_list) > 1:
+                    v = v + 1
+                else:
+                     break
+        self.version = v
+
         d = datetime.datetime.fromtimestamp(time.time(), pytz.UTC)
         if not self.creation_date:
             self.creation_date = d
@@ -48,4 +120,3 @@ class passDb(models.Model):
             self.deprecated = True
         super(passDb, self).save(*args, **kwargs)
 
-    

--- a/passManager/models.py
+++ b/passManager/models.py
@@ -13,7 +13,7 @@ class ITService(models.Model):
     def __unicode__(self):
         return self.name
 
-    name = models.CharField(max_length=500) # Unique
+    name = models.CharField(max_length=500,unique=True)
     notes = models.TextField(null=True, blank=True, default = "")
 
 class ITConfigurationItem(models.Model):
@@ -42,7 +42,7 @@ class PasswordType(models.Model):
         except Exception:
             return super(PasswordType, self).__unicode__(*args, **kwargs)
 
-    name = models.CharField(max_length=100) #Unique
+    name = models.CharField(max_length=100,unique=True)
     notes = models.TextField(null=True, blank=True, default = "")
 
 class passDb(models.Model):
@@ -78,7 +78,6 @@ class passDb(models.Model):
 
     def getClickMe(self):
         password = passEncr('decrypt', self.password)
-        # TODO: BadSignature
         idrow = self.id
         return '<font color="red"><span id=\"%s\" onClick=\"cambiar(\'%s\',\'%s\');\">ClickME</span></font>' % (idrow, idrow, password)
     getClickMe.allow_tags = True

--- a/passManager/models.py
+++ b/passManager/models.py
@@ -50,6 +50,7 @@ class passDb(models.Model):
         verbose_name = 'Password'
 
     deprecated = models.BooleanField(default=False)
+    active = models.BooleanField(default=True)
     account = models.CharField(max_length=100)
     name = models.CharField(max_length=500)
     version = models.IntegerField(default=1)
@@ -57,14 +58,14 @@ class passDb(models.Model):
     ci = models.ForeignKey(ITConfigurationItem)
     login = models.CharField(max_length=50)
     password = models.CharField(max_length=100)
-    server = models.CharField(max_length=60)
+    server = models.CharField(max_length=60,null=True, blank=True, default= "")
     service_name = models.CharField(max_length=500)
     uploader = models.ForeignKey(User)
     notes = models.TextField(null=True, blank=True, default = "")
     creation_date = models.DateTimeField(editable=False)
     modification_date = models.DateTimeField(auto_now=True, null=True,
             blank=True)
-    valid_since_date = models.DateTimeField(null=True, blank=True, default = None)
+    # valid_since_date = models.DateTimeField(null=True, blank=True, default = None)
     valid_until_date = models.DateTimeField(null=True, blank=True, default = None)
 
     def __unicode__(self):
@@ -74,7 +75,6 @@ class passDb(models.Model):
             ci_str = "no CI"
         return ci_str + \
                 "::" + self.account + "::" + str(self.version)
-
 
     def getClickMe(self):
         password = passEncr('decrypt', self.password)
@@ -117,5 +117,10 @@ class passDb(models.Model):
             self.creation_date = d
         if self.valid_until_date and self.valid_until_date < d:
             self.deprecated = True
+        else:
+            self.deprecated = False
+
+        self.active = not self.deprecated
+
         super(passDb, self).save(*args, **kwargs)
 

--- a/passManager/utils/helpers.py
+++ b/passManager/utils/helpers.py
@@ -1,0 +1,87 @@
+import passManager
+import csv
+
+def get_model_fields(model):
+    return model._meta.fields
+
+def get_model_field_names(model):
+    res = []
+    for field in get_model_fields(model):
+        f = field.name
+        res.append(f)
+    return res
+
+def get_model_fields_values(modelobj):
+    res = []
+    for field in get_model_fields(modelobj):
+        f = str(getattr(modelobj, field.name))
+        res.append(f)
+    return res
+
+def from_model_to_csv_header(model):
+    row = ''
+    for field in get_model_fields(model):
+        f = field.name
+        f = f.replace('"','""')
+        row += '"' + f + '",'
+    return row
+
+def from_model_to_csv_row(modelobj):
+    row = ""
+    for field in get_model_fields(modelobj):
+        f = str(getattr(modelobj, field.name))
+        f = f.replace('"','""')
+        row += '"' + f + '",'
+    return row
+
+def from_model_to_csv(model,q,fileobj):
+
+    writer = csv.writer(fileobj)
+    for o in model.objects.filter(q):
+        csv_row = from_model_to_csv_row(o)
+        writer.writerow(csv_row)
+
+
+def from_csv_to_model(model,fileobj,extrafunc=None):
+    '''
+            modelobj = extrafunc(model,modelobj,row,headers)
+    '''
+    csv_reader = csv.reader(fileobj)
+    headers = csv_reader.next()
+    for row in csv_reader:
+        modelobj = None
+        try:
+            index_id = headers.index("id")
+            modelobj = model.objects.get(id=row[index_id])
+        except Exception, e:
+            pass
+        if extrafunc:
+            modelobj = extrafunc(model,modelobj,row, headers)
+
+        if not modelobj:
+            modelobj = model()
+
+        for i in range(0,len(row)-1):
+            try:
+                header = headers[i]
+                value = row[i]
+                if header == "id":
+                    continue
+                if value in ["True", "False"]:
+                    value = eval(value)
+                try:
+                    from dateutil.parser import parse
+                    value = parse(value)
+                except Exception, e:
+                    pass
+
+                # print "header: %s value: %s" % (header, value)
+                old_value = getattr(modelobj,header)
+                setattr(modelobj,header, value)
+                try:
+                    modelobj.save()
+                except Exception, e:
+                    setattr(modelobj,header, old_value)
+            except Exception, e:
+                pass
+

--- a/passManager/utils/helpers.py
+++ b/passManager/utils/helpers.py
@@ -77,8 +77,9 @@ def from_csv_to_model(model,fileobj,extrafunc=None):
                 if value in ["True", "False"]:
                     value = eval(value)
                 try:
-                    from dateutil.parser import parse
-                    value = parse(value)
+                    if len(value.strip()) > 0:
+                        from dateutil.parser import parse
+                        value = parse(value)
                 except Exception, e:
                     pass
 

--- a/passManager/utils/helpers.py
+++ b/passManager/utils/helpers.py
@@ -18,6 +18,13 @@ def get_model_fields_values(modelobj):
         res.append(f)
     return res
 
+def clone_model(modelobj):
+    new = modelobj.__class__()
+    for field in get_model_fields(modelobj):
+        value = getattr(modelobj, field.name)
+        setattr(new,field.name,value)
+    return new
+
 def from_model_to_csv_header(model):
     row = ''
     for field in get_model_fields(model):

--- a/passManager/utils/helpers.py
+++ b/passManager/utils/helpers.py
@@ -1,5 +1,6 @@
 import passManager
 import csv
+from django.db import transaction
 
 def get_model_fields(model):
     return model._meta.fields
@@ -48,7 +49,7 @@ def from_model_to_csv(model,q,fileobj):
         csv_row = from_model_to_csv_row(o)
         writer.writerow(csv_row)
 
-
+@transaction.commit_on_success
 def from_csv_to_model(model,fileobj,extrafunc=None):
     '''
             modelobj = extrafunc(model,modelobj,row,headers)

--- a/passManager/views.py
+++ b/passManager/views.py
@@ -7,6 +7,7 @@ from django.contrib.auth.models import User
 from django.forms import CharField
 from django.template import RequestContext
 from django.forms import TextInput, Textarea, PasswordInput, HiddenInput
+from django.conf import settings
 
 class ContactPassForm(forms.ModelForm):
     mailto = forms.EmailField(label='Destinatario')
@@ -37,22 +38,23 @@ def sendPassEmailView(request, rowid):
             server = form.cleaned_data['server']
             notes = form.cleaned_data['notes']
             mailto = form.cleaned_data['mailto']
-            sender = 'PassManager@example.com'
+            sender = settings.PASS_MANAGER_EMAIL_FROM
             
-            subject = "Django-PassManager - %s" % name
+            subject = "%s - %s" % (settings.PASS_MANAGER_EMAIL_SUBJECT, name)
             text_message ="""Django-PassManager
-            Nombre: %s
+            Name: %s
             Login: %s
             Password: %s
             Server: %s
-            notas %s""" % (name, login, password, server, notes)
+            Notes: %s""" % (name, login, password, server, notes)
             
-            html_message = """<h2>Django - PassManager</h2>
-            <p><strong>Nombre: </strong> %s</p>
+            html_message = """<h2>%s</h2>
+            <p><strong>Name: </strong> %s</p>
             <p><strong>Login: </strong> %s</p>
             <p><strong>Password: </strong> %s</p>
             <p><strong>Server: </strong> %s</p>
-            <p><strong>NOTAS: </strong> %s</p>""" % (name, login, password, server, notes)
+            <p><strong>Notes: </strong> %s</p>""" \
+% (settings.PASS_MANAGER_EMAIL_TITLE, name, login, password, server, notes)
             
             msg = EmailMultiAlternatives(subject, text_message, sender, [mailto])
             msg.attach_alternative(html_message, "text/html")

--- a/settings.py
+++ b/settings.py
@@ -14,8 +14,8 @@ MANAGERS = ADMINS
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.mysql', # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': 'passmanager',                      # Or path to database file if using sqlite3.
+        'ENGINE': 'django.db.backends.sqlite3', # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
+        'NAME': 'passmanager.sqlite',                      # Or path to database file if using sqlite3.
         'USER': 'passmanager',                      # Not used with sqlite3.
         'PASSWORD': 'passmanager',                  # Not used with sqlite3.
         'HOST': 'localhost',                      # Set to empty string for localhost. Not used with sqlite3.
@@ -127,6 +127,16 @@ INSTALLED_APPS = (
     # APLICACIONES
     'passManager',
 )
+
+
+
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST = '127.0.0.1'
+EMAIL_PORT = 25
+
+PASS_MANAGER_EMAIL_FROM="noreply@example.com"
+PASS_MANAGER_EMAIL_SUBJECT="Credentials"
+PASS_MANAGER_EMAIL_TITLE="Credentials"
 
 INTERNAL_IPS = (
                 '127.0.0.1',

--- a/settings.py
+++ b/settings.py
@@ -31,6 +31,7 @@ DATABASES = {
 # If running in a Windows environment this must be set to the same as your
 # system time zone.
 TIME_ZONE = 'Europe/Madrid'
+USE_TZ = True
 
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html

--- a/settings.py
+++ b/settings.py
@@ -126,6 +126,7 @@ INSTALLED_APPS = (
     #'django.contrib.admindocs',
     # APLICACIONES
     'passManager',
+    'south',
 )
 
 

--- a/settings.py
+++ b/settings.py
@@ -156,9 +156,15 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
+    'filters': {
+        'require_debug_false': {
+             '()': 'django.utils.log.RequireDebugFalse'
+        }
+    },
     'handlers': {
         'mail_admins': {
             'level': 'ERROR',
+            'filters': ['require_debug_false'],
             'class': 'django.utils.log.AdminEmailHandler'
         }
     },

--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -6,7 +6,7 @@ PassManager
 {% endblock %}
 
 {% block branding %}
-<a href="{% url admin:index %}">
+<a href="{% url "admin:index" %}">
   <img style="float:left; margin: -6px 4px 4px 4px"
        src="/static/pwm_logo.png"/>
 </a>

--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -6,7 +6,7 @@ PassManager
 {% endblock %}
 
 {% block branding %}
-<a href="{% url "admin:index" %}">
+<a href="{% url admin:index %}">
   <img style="float:left; margin: -6px 4px 4px 4px"
        src="/static/pwm_logo.png"/>
 </a>

--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -1,7 +1,8 @@
 {% extends "admin/base_site.html" %}
 {% load i18n %}
+{% load staticfiles %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% load adminmedia %}{% admin_media_prefix %}css/dashboard.css" />{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static 'admin/css/dashboard.css' %}" />{% endblock %}
 
 {% block coltype %}colMS{% endblock %}
 

--- a/tools/import-from-csv
+++ b/tools/import-from-csv
@@ -34,7 +34,8 @@ import settings
 setup_environ(settings)
 
 from passManager.utils.helpers import *
-from passManager.models import passDb, passEncr
+from passManager.models import passDb, passEncr, PasswordType
+from passManager.models import ITConfigurationItem, ITService
 from django.contrib.auth.models import User
 
 def extra_passDb(model,modelobj,row,headers):
@@ -46,31 +47,67 @@ def extra_passDb(model,modelobj,row,headers):
                 modelobj = found_objects[0]
             else:
                 modelobj = model()
-        except Exception:
+        except Exception, e:
             modelobj = model()
+
+    try:
+        index_password_type \
+            = headers.index("password_type")
+        try:
+            type_ = PasswordType.objects.filter(name=row[index_password_type])[0]
+        except Exception, e:
+            type_ = PasswordType(name=row[index_password_type])
+            type_.save()
+        modelobj.password_type = type_
+    except Exception, e:
+        pass
+
+    try:
+        index_ci \
+            = headers.index("ci")
+        new_value = row[index_ci]
+        service_name,ci_name = new_value.split("::")
+        try:
+            service_ = ITService.objects.filter(name=service_name)[0]
+        except Exception, e:
+            service_ = ITService(name=service_name)
+            service_.save()
+        try:
+            ci_ = ITConfigurationItem.objects.filter(name=ci_name,service__name=service_name)[0]
+        except Exception, e:
+            ci_ = ITConfigurationItem(name=ci_name,service=service_)
+            ci_.save()
+        modelobj.ci = ci_
+    except Exception, e:
+        pass
+
     try:
         index_unencrypted_password = headers.index("unencrypted_password")
         old_value = modelobj.password
         modelobj.password = passEncr('encrypt',
                  row[index_unencrypted_password])
         try:
-            modelobj.save()
+            pass
+            # modelobj.save()
         except Exception:
             modelobj.password=old_value
     except Exception:
         pass
+
     try:
         index_uploader = headers.index("uploader")
         old_value = modelobj.uploader
         modelobj.uploader = \
                 User.objects.get(username=row[index_uploader])
         try:
-            modelobj.save()
+            pass
+            # modelobj.save()
         except Exception:
             modelobj.uploader=old_value
     except Exception, e:
         modelobj.uploader_id = 1
         # User.objects.filter(username=row[index_uploader])
+
     return modelobj
 
 

--- a/tools/import-from-csv
+++ b/tools/import-from-csv
@@ -1,0 +1,95 @@
+#!/usr/bin/python
+# -*- coding:utf-8 -*-
+
+# Author: Pablo Saavedra Rodinho
+# Contact: pablo.saavedra@interoud.com
+
+"""
+Import credentials from a CSV formatted file
+"""
+import os
+import sys
+from optparse import OptionParser
+import ConfigParser
+
+reload(sys)
+sys.setdefaultencoding('utf-8')
+
+from django.core.management import setup_environ
+import imp
+
+try:
+    imp.find_module('settings') # Assumed to be in the same directory.
+except ImportError:
+    import sys
+    sys.stderr.write('''Error: Can't find the file 'settings.py' in the
+    directory containing %r. It appears you've customized things.\n
+    You'll have to run django-admin.py, passing it your settings
+    module.\n''' % __file__)
+    sys.exit(1)
+
+import settings
+
+# execute_manager(settings)
+setup_environ(settings)
+
+from passManager.utils.helpers import *
+from passManager.models import passDb, passEncr
+from django.contrib.auth.models import User
+
+def extra_passDb(model,modelobj,row,headers):
+    if not modelobj:
+        try:
+            index_name = headers.index("name")
+            found_objects = model.objects.filter(name=row[index_name])
+            if len(found_objects) == 1:
+                modelobj = found_objects[0]
+            else:
+                modelobj = model()
+        except Exception:
+            modelobj = model()
+    try:
+        index_unencrypted_password = headers.index("unencrypted_password")
+        old_value = modelobj.password
+        modelobj.password = passEncr('encrypt',
+                 row[index_unencrypted_password])
+        try:
+            modelobj.save()
+        except Exception:
+            modelobj.password=old_value
+    except Exception:
+        pass
+    try:
+        index_uploader = headers.index("uploader")
+        old_value = modelobj.uploader
+        modelobj.uploader = \
+                User.objects.get(username=row[index_uploader])
+        try:
+            modelobj.save()
+        except Exception:
+            modelobj.uploader=old_value
+    except Exception, e:
+        modelobj.uploader_id = 1
+        # User.objects.filter(username=row[index_uploader])
+    return modelobj
+
+
+
+###############################################################################
+
+### Parameters
+filename="./credentials.csv"
+
+################################################################################
+
+parser = OptionParser()
+
+parser.add_option("-f", "--file", dest="filename", default=filename,
+                help="CSV file", metavar="CSVFILE")
+
+(options, args) = parser.parse_args()
+if options.filename:
+    filename = options.filename
+
+f = file(filename)
+from_csv_to_model(passDb,f,extra_passDb)


### PR DESCRIPTION
Buenos ías, el otros día buscando proyectos de gestión de contraseñas hechos en Django me topé con el tuyo.
Por su simplicidad encajó perfectamente en lo que necesitaba, si bien lo he extendido un poco para poder usarlo en nuestra oficina. Básicamente los cambios hechos se centran en pequeñas modificaciones del admin.py y en la 
inclusión de tres nuevas entidades relacionadas a las contraseñas: Services, Configuration Items y Type of Credential. El objeto de estas nuevas entidades es poder agrupar las contraseñas por grupos ed servicios y asociarlos a componentes (CI). 

A mayores he dispuesto de una nueva acción que es la de exportar a CSV y una herramienta en linea de comandos para poder importar de CSV. También he añadido soporte "South" para hacer más simple el proceso
de migración y actualización del modelo Entidad-Relación (versionado de Base de Datos)

Espero que este parche sea de tu agrado y quieras finalmente añadirlo a tú repositorio. Yo estaría encantado de 
mandar pequeñas actualizaciones a medida que lo vayamos requiriendo.

Un saludo desde Coruña

Resumen:
- Nuevas clases en el modelo Services, Configuration Items y Type of Credential
- Exportar/Importar de CSV
- Modificación del formulario de passDbAmin para que la contraseña salga en claro y evitar problemas de corrupción de contraseñas. Se añada un nuevo widget a tal efecto dentro del admin.py
- El correo saliente ahora es personalizable desde el settings.py
- Se añade soporte South para el versionado de la Base de Datos
- Se solucionan problemas de compatibilidad con Django 1.5

Por hacer:
- Personalizar en widget que muestra la contraseña al estilo del ClikMe (ocultar/ver contraseña)
